### PR TITLE
Added Xcode 11.2 support

### DIFF
--- a/Sources/DTTableViewManager/DTTableViewDelegate.swift
+++ b/Sources/DTTableViewManager/DTTableViewDelegate.swift
@@ -232,7 +232,7 @@ open class DTTableViewDelegate : DTTableViewDelegateWrapper, UITableViewDelegate
         (delegate as? UITableViewDelegate)?.tableView?(tableView, accessoryButtonTappedForRowWith: indexPath)
     }
     
-    #if os(iOS)
+#if os(iOS)
     @available(iOS, deprecated: 13.0)
     /// Implementation for `UITableViewDelegate` protocol
     open func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
@@ -241,24 +241,28 @@ open class DTTableViewDelegate : DTTableViewDelegateWrapper, UITableViewDelegate
         }
         return (delegate as? UITableViewDelegate)?.tableView?(tableView, editActionsForRowAt: indexPath)
     }
-    #endif
-    
-    #if os(iOS)
+
     /// Implementation for `UITableViewDelegate` protocol
     open func tableView(_ tableView: UITableView, willBeginEditingRowAt indexPath: IndexPath) {
         _ = performCellReaction(.willBeginEditingRowAtIndexPath, location: indexPath, provideCell: true)
         (delegate as? UITableViewDelegate)?.tableView?(tableView, willBeginEditingRowAt: indexPath)
     }
-    #endif
     
-    #if os(iOS)
     /// Implementation for `UITableViewDelegate` protocol
     open func tableView(_ tableView: UITableView, didEndEditingRowAt indexPath: IndexPath?) {
         defer { (delegate as? UITableViewDelegate)?.tableView?(tableView, didEndEditingRowAt: indexPath) }
         guard let indexPath = indexPath else { return }
         _ = performCellReaction(.didEndEditingRowAtIndexPath, location: indexPath, provideCell: true)
     }
-    #endif
+    
+    /// Implementation for `UITableViewDelegate` protocol
+    open func tableView(_ tableView: UITableView, titleForDeleteConfirmationButtonForRowAt indexPath: IndexPath) -> String? {
+        if let eventReaction = cellReaction(.titleForDeleteButtonForRowAtIndexPath, location: indexPath) {
+            return performNillableCellReaction(eventReaction, location: indexPath, provideCell: true) as? String
+        }
+        return (delegate as? UITableViewDelegate)?.tableView?(tableView, titleForDeleteConfirmationButtonForRowAt: indexPath)
+    }
+#endif
     
 #if swift(>=4.2)
     /// Implementation for `UITableViewDelegate` protocol
@@ -277,17 +281,7 @@ open class DTTableViewDelegate : DTTableViewDelegateWrapper, UITableViewDelegate
         return (delegate as? UITableViewDelegate)?.tableView?(tableView, editingStyleForRowAt: indexPath) ?? .none
     }
 #endif
-    
-    #if os(iOS)
-    /// Implementation for `UITableViewDelegate` protocol
-    open func tableView(_ tableView: UITableView, titleForDeleteConfirmationButtonForRowAt indexPath: IndexPath) -> String? {
-        if let eventReaction = cellReaction(.titleForDeleteButtonForRowAtIndexPath, location: indexPath) {
-            return performNillableCellReaction(eventReaction, location: indexPath, provideCell: true) as? String
-        }
-        return (delegate as? UITableViewDelegate)?.tableView?(tableView, titleForDeleteConfirmationButtonForRowAt: indexPath)
-    }
-    #endif
-    
+
     /// Implementation for `UITableViewDelegate` protocol
     open func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
         if let should = performCellReaction(.shouldIndentWhileEditingRowAtIndexPath, location: indexPath, provideCell: true) as? Bool {
@@ -381,7 +375,7 @@ open class DTTableViewDelegate : DTTableViewDelegateWrapper, UITableViewDelegate
         }
         return (delegate as? UITableViewDelegate)?.tableView?(tableView, canFocusRowAt: indexPath) ?? tableView.cellForRow(at: indexPath)?.canBecomeFocused ?? true
     }
-    #if os(iOS)
+#if os(iOS)
     @available (iOS 11, *)
     /// Implementation for `UITableViewDelegate` protocol
     open func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
@@ -415,7 +409,7 @@ open class DTTableViewDelegate : DTTableViewDelegateWrapper, UITableViewDelegate
                                                               shouldSpringLoadRowAt:indexPath,
                                                               with: context) ?? true
     }
-    #endif
+#endif
     
     /// Implementation for `UITableViewDelegate` protocol
     open func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
@@ -459,8 +453,7 @@ open class DTTableViewDelegate : DTTableViewDelegateWrapper, UITableViewDelegate
         return (delegate as? UITableViewDelegate)?.indexPathForPreferredFocusedView?(in: tableView)
     }
     
-#if compiler(>=5.1)
-    #if os(iOS)
+#if compiler(>=5.1) && os(iOS)
     @available(iOS 13.0, *)
     /// Implementation for `UITableViewDelegate` protocol
     open func tableView(_ tableView: UITableView, shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool {
@@ -515,7 +508,7 @@ open class DTTableViewDelegate : DTTableViewDelegateWrapper, UITableViewDelegate
         }
         return (delegate as? UITableViewDelegate)?.tableView?(tableView, previewForDismissingContextMenuWithConfiguration: configuration)
     }
-    
+    #if compiler(<5.1.2)
     @available(iOS 13.0, *)
     /// Implementation for `UITableViewDelegate` protocol
     open func tableView(_ tableView: UITableView, willCommitMenuWithAnimator animator: UIContextMenuInteractionCommitAnimating) {

--- a/Sources/DTTableViewManager/DTTableViewManager+Delegate.swift
+++ b/Sources/DTTableViewManager/DTTableViewManager+Delegate.swift
@@ -70,14 +70,6 @@ extension DTTableViewManager {
         tableDelegate?.appendReaction(for: T.self, signature: .willDisplayCellForRowAtIndexPath, closure: closure)
     }
     
-    #if os(iOS)
-    @available(iOS, deprecated: 13.0)
-    /// Registers `closure` to be executed, when `UITableViewDelegate.tableView(_:editActionsForRowAt:)` method is called for `cellClass`.
-    open func editActions<T:ModelTransfer>(for cellClass: T.Type, _ closure: @escaping (T, T.ModelType, IndexPath) -> [UITableViewRowAction]?) where T: UITableViewCell {
-        tableDelegate?.appendReaction(for: T.self, signature: .editActionsForRowAtIndexPath, closure: closure)
-    }
-    #endif
-    
     /// Registers `closure` to be executed, when `UITableViewDelegate.tableView(_:accessoryButtonTappedForRowAt:)` method is called for `cellClass`.
     open func accessoryButtonTapped<T:ModelTransfer>(in cellClass: T.Type, _ closure: @escaping (T, T.ModelType, IndexPath) -> Void) where T: UITableViewCell {
         tableDelegate?.appendReaction(for: T.self, signature: .accessoryButtonTappedForRowAtIndexPath, closure: closure)
@@ -115,7 +107,13 @@ extension DTTableViewManager {
         tableDelegate?.appendReaction(forSupplementaryKind: DTTableViewElementSectionFooter, supplementaryClass: T.self, signature: .willDisplayFooterForSection, closure: closure)
     }
     
-    #if os(iOS)
+#if os(iOS)
+    @available(iOS, deprecated: 13.0)
+    /// Registers `closure` to be executed, when `UITableViewDelegate.tableView(_:editActionsForRowAt:)` method is called for `cellClass`.
+    open func editActions<T:ModelTransfer>(for cellClass: T.Type, _ closure: @escaping (T, T.ModelType, IndexPath) -> [UITableViewRowAction]?) where T: UITableViewCell {
+        tableDelegate?.appendReaction(for: T.self, signature: .editActionsForRowAtIndexPath, closure: closure)
+    }
+    
     /// Registers `closure` to be executed, when `UITableViewDelegate.tableView(_:willBeginEditingRowAt:)` method is called for `cellClass`.
     open func willBeginEditing<T:ModelTransfer>(_ cellClass:T.Type, _ closure: @escaping (T, T.ModelType, IndexPath) -> Void) where T: UITableViewCell
     {
@@ -127,7 +125,13 @@ extension DTTableViewManager {
     {
         tableDelegate?.appendReaction(for: T.self, signature: .didEndEditingRowAtIndexPath, closure: closure)
     }
-    #endif
+    
+    /// Registers `closure` to be executed, when `UITableViewDelegate.tableView(_:titleForDeleteConfirmationButtonForRowAt:)` method is called for `cellClass`.
+    open func titleForDeleteConfirmationButton<T:ModelTransfer>(in cellClass:T.Type, _ closure: @escaping (T, T.ModelType, IndexPath) -> String?) where T: UITableViewCell
+    {
+        tableDelegate?.appendReaction(for: T.self, signature: .titleForDeleteButtonForRowAtIndexPath, closure: closure)
+    }
+#endif
     
 #if swift(>=4.2)
     /// Registers `closure` to be executed, when `UITableViewDelegate.tableView(_:editingStyleForRowAt:)` method is called for cell that contains item `ofType` at `indexPath`.
@@ -142,14 +146,6 @@ extension DTTableViewManager {
         tableDelegate?.appendReaction(for: T.self, signature: .editingStyleForRowAtIndexPath, closure: closure)
     }
 #endif
-    
-    #if os(iOS)
-    /// Registers `closure` to be executed, when `UITableViewDelegate.tableView(_:titleForDeleteConfirmationButtonForRowAt:)` method is called for `cellClass`.
-    open func titleForDeleteConfirmationButton<T:ModelTransfer>(in cellClass:T.Type, _ closure: @escaping (T, T.ModelType, IndexPath) -> String?) where T: UITableViewCell
-    {
-        tableDelegate?.appendReaction(for: T.self, signature: .titleForDeleteButtonForRowAtIndexPath, closure: closure)
-    }
-    #endif
     
     /// Registers `closure` to be executed, when `UITableViewDelegate.tableView(_:shouldIndentWhileEditingRowAt:)` method is called for `cellClass`.
     open func shouldIndentWhileEditing<T:ModelTransfer>(_ cellClass:T.Type, _ closure: @escaping (T, T.ModelType, IndexPath) -> Bool) where T: UITableViewCell
@@ -253,7 +249,7 @@ extension DTTableViewManager {
                                                closure: closure)
     }
     
-    #if os(iOS)
+#if os(iOS)
     @available(iOS 11, *)
     /// Registers `closure` to be executed when `UITableViewDelegate.tableView(_:leadingSwipeActionsConfigurationForRowAt:)` method is called for `cellClass`
     open func leadingSwipeActionsConfiguration<T:ModelTransfer>(for cellClass: T.Type, _ closure: @escaping (T, T.ModelType, IndexPath) -> UISwipeActionsConfiguration?) where T: UITableViewCell {
@@ -278,7 +274,7 @@ extension DTTableViewManager {
                                                closure: closure)
     }
     
-#if compiler(>=5.1)
+    #if compiler(>=5.1)
     @available(iOS 13, *)
     /// Registers `closure` to be executed when `UITableViewDelegate.tableView(_:shouldBeginMultipleSelectionInteractionAt:)`method is called for `cellClass`.
     /// - Parameter Type: cell class to react for event
@@ -336,13 +332,14 @@ extension DTTableViewManager {
     {
         tableDelegate?.appendNonCellReaction(.previewForDismissingContextMenu, closure: closure)
     }
-    
+        #if compiler(<5.1.2)
     @available(iOS 13.0, *)
     /// Registers `closure` to be executed when `UITableViewDelegate.tableView(_:willCommitMenuWithAnimator:)` method is called
     open func willCommitMenuWithAnimator(_ closure: @escaping (UIContextMenuInteractionCommitAnimating) -> Void)
     {
         tableDelegate?.appendNonCellReaction(.willCommitMenuWithAnimator, closure: closure)
     }
+        #endif
     #endif
 #endif
 }


### PR DESCRIPTION
`[UITableViewDelegate tableView:willCommitMenuWithAnimator:]` method has been removed in iOS 13.2 SDK, thus additional compiler directive is needed to be compatible with latest SDK. 